### PR TITLE
Skip nested queries

### DIFF
--- a/expected/pg_mon.out
+++ b/expected/pg_mon.out
@@ -1,6 +1,5 @@
 create extension pg_mon;
 create extension pg_stat_statements;
-set pg_stat_statements.track = 'all';
 create table t (i int, j text);
 create table t2 (i int, j text);
 insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -350,6 +350,7 @@ pgmon_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
                         prev_ExecutorRun(queryDesc, direction, count, execute_once);
                 else
                         standard_ExecutorRun(queryDesc, direction, count, execute_once);
+                nesting_level--;
         }
 #if PG_VERSION_NUM < 130000
         PG_CATCH();
@@ -384,6 +385,7 @@ pgmon_ExecutorFinish(QueryDesc *queryDesc)
                         prev_ExecutorFinish(queryDesc);
                 else
                         standard_ExecutorFinish(queryDesc);
+                nesting_level--;
         }
 #if PG_VERSION_NUM < 130000
         PG_CATCH();

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -287,7 +287,7 @@ pgmon_ExecutorStart(QueryDesc *queryDesc, int eflags)
         else
                 standard_ExecutorStart(queryDesc, eflags);
 
-    if (queryDesc->plannedstmt->queryId != UINT64CONST(0))
+    if (queryDesc->plannedstmt->queryId != UINT64CONST(0) && nesting_level == 0)
     {
        /*
         * Set up to track total elapsed time in ExecutorRun.Make sure the space

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -350,7 +350,9 @@ pgmon_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
                         prev_ExecutorRun(queryDesc, direction, count, execute_once);
                 else
                         standard_ExecutorRun(queryDesc, direction, count, execute_once);
+#if PG_VERSION_NUM < 130000
                 nesting_level--;
+#endif
         }
 #if PG_VERSION_NUM < 130000
         PG_CATCH();
@@ -377,16 +379,18 @@ pgmon_ExecutorFinish(QueryDesc *queryDesc)
     {
        temp_entry.first_tuple_time = queryDesc->planstate->instrument->firsttuple * 1000;
     }
-        nesting_level++;
+    nesting_level++;
 
-        PG_TRY();
-        {
-                if (prev_ExecutorFinish)
-                        prev_ExecutorFinish(queryDesc);
-                else
-                        standard_ExecutorFinish(queryDesc);
-                nesting_level--;
-        }
+    PG_TRY();
+    {
+            if (prev_ExecutorFinish)
+                    prev_ExecutorFinish(queryDesc);
+            else
+                    standard_ExecutorFinish(queryDesc);
+#if PG_VERSION_NUM < 130000
+            nesting_level--;
+#endif
+    }
 #if PG_VERSION_NUM < 130000
         PG_CATCH();
 	{

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -375,7 +375,7 @@ pgmon_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
 static void
 pgmon_ExecutorFinish(QueryDesc *queryDesc)
 {
-    if (queryDesc->planstate->instrument)
+    if (queryDesc->planstate->instrument && nesting_level == 0)
     {
        temp_entry.first_tuple_time = queryDesc->planstate->instrument->firsttuple * 1000;
     }

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -457,6 +457,7 @@ pgmon_plan_store(QueryDesc *queryDesc)
          */
         if (CONFIG_PLAN_INFO_IMMEDIATE && !CONFIG_PLAN_INFO_DISABLE)
         {
+            LWLockAcquire(mon_lock, LW_SHARED);
             entry = create_or_get_entry(temp_entry, temp_entry.queryid);
 
             e = (volatile mon_rec *) entry;
@@ -482,6 +483,7 @@ pgmon_exec_store(QueryDesc *queryDesc)
         if (!mon_ht)
                 return;
 
+        LWLockAcquire(mon_lock, LW_SHARED);
         entry = create_or_get_entry(temp_entry, queryId);
 
         e = (volatile mon_rec *) entry;
@@ -586,7 +588,6 @@ static mon_rec * create_or_get_entry(mon_rec temp_entry, int64 queryId)
     mon_rec *entry = NULL;
     bool found = false;
 
-    LWLockAcquire(mon_lock, LW_SHARED);
     entry = (mon_rec *) hash_search(mon_ht, &queryId, HASH_FIND, &found);
 
     if (!entry)

--- a/sql/pg_mon.sql
+++ b/sql/pg_mon.sql
@@ -1,8 +1,6 @@
 create extension pg_mon;
 create extension pg_stat_statements;
 
-set pg_stat_statements.track = 'all';
-
 create table t (i int, j text);
 create table t2 (i int, j text);
 insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));


### PR DESCRIPTION
Replicate the default behavior of pg_stat_statements and skip the
nested queries for pg_mon.

Cleanup the pg_mon hash table only when creating new entry in an
already full hash table.