### PR TITLE
Add the scan information for update queries

### DIFF
--- a/expected/pg_mon.out
+++ b/expected/pg_mon.out
@@ -2,8 +2,8 @@ create extension pg_mon;
 create extension pg_stat_statements;
 create table t (i int, j text);
 create table t2 (i int, j text);
-insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));
-insert into t2 values (generate_series(1,10), repeat('sdsfefedc', 10));
+insert into t values (generate_series(1,10), repeat('test_pg_mon', 10));
+insert into t2 values (generate_series(1,10), repeat('test_pg_mon', 10));
 analyze t;
 analyze t2;
 -- Seq scan query output
@@ -20,18 +20,18 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t;
- i  |                                                  j                                                   
-----+------------------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
+ i  |                                                       j                                                        
+----+----------------------------------------------------------------------------------------------------------------
+  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, hist_time_ubounds, hist_time_freq from pg_mon where seq_scans IS NOT NULL;
@@ -57,12 +57,12 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t where i < 5;
- i |                                                  j                                                   
----+------------------------------------------------------------------------------------------------------
- 1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
+ i |                                                       j                                                        
+---+----------------------------------------------------------------------------------------------------------------
+ 1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (4 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, hist_time_ubounds, hist_time_freq from pg_mon where index_scans IS NOT NULL;
@@ -74,12 +74,12 @@ select expected_rows, actual_rows, seq_scans, index_scans, hist_time_ubounds, hi
 --When query changes scan method
 set enable_indexscan = 'off';
 select * from t where i < 5;
- i |                                                  j                                                   
----+------------------------------------------------------------------------------------------------------
- 1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
+ i |                                                       j                                                        
+---+----------------------------------------------------------------------------------------------------------------
+ 1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (4 rows)
 
 select expected_rows, actual_rows, index_scans, bitmap_scans, hist_time_ubounds, hist_time_freq from pg_mon where index_scans IS NOT NULL and bitmap_scans IS NOT NULL;
@@ -90,12 +90,12 @@ select expected_rows, actual_rows, index_scans, bitmap_scans, hist_time_ubounds,
 
 set enable_bitmapscan = 'off';
 select * from t where i < 5;
- i |                                                  j                                                   
----+------------------------------------------------------------------------------------------------------
- 1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
- 4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h
+ i |                                                       j                                                        
+---+----------------------------------------------------------------------------------------------------------------
+ 1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (4 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, bitmap_scans, hist_time_ubounds, hist_time_freq from pg_mon where seq_scans IS NOT NULL and index_scans IS NOT NULL;
@@ -104,6 +104,81 @@ select expected_rows, actual_rows, seq_scans, index_scans, bitmap_scans, hist_ti
              3 |           4 | {t}       | {t_i_idx}   | {t_i_idx}    | {1}               | {3}
 (1 row)
 
+--Scan information for update statements
+set enable_indexscan = 'on';
+set enable_bitmapscan = 'on';
+update t set i = 11 where i = 1;
+select seq_scans,  index_scans, update_query from pg_mon where update_query = true;
+ seq_scans | index_scans | update_query 
+-----------+-------------+--------------
+ {}        | {t_i_idx}   | t
+(1 row)
+
+select pg_mon_reset();
+ pg_mon_reset 
+--------------
+ 
+(1 row)
+
+select pg_stat_statements_reset();
+ pg_stat_statements_reset 
+--------------------------
+ 
+(1 row)
+
+set enable_indexscan = 'off';
+set enable_bitmapscan = 'off';
+update t set i = 1;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+ seq_scans | index_scans | update_query 
+-----------+-------------+--------------
+ {t}       | {}          | t
+(1 row)
+
+--Scan information for delete statements
+select pg_mon_reset();
+ pg_mon_reset 
+--------------
+ 
+(1 row)
+
+select pg_stat_statements_reset();
+ pg_stat_statements_reset 
+--------------------------
+ 
+(1 row)
+
+set enable_indexscan = 'on';
+set enable_bitmapscan = 'on';
+delete from t where i < 5;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+ seq_scans | index_scans | update_query 
+-----------+-------------+--------------
+ {}        | {t_i_idx}   | t
+(1 row)
+
+select pg_mon_reset();
+ pg_mon_reset 
+--------------
+ 
+(1 row)
+
+select pg_stat_statements_reset();
+ pg_stat_statements_reset 
+--------------------------
+ 
+(1 row)
+
+set enable_indexscan = 'off';
+set enable_bitmapscan = 'off';
+delete from t;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+ seq_scans | index_scans | update_query 
+-----------+-------------+--------------
+ {t}       | {}          | t
+(1 row)
+
+insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));
 --Join output
 select pg_mon_reset();
  pg_mon_reset 
@@ -118,18 +193,18 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
- i  |                                                  j                                                   | i  |                                             j                                              
-----+------------------------------------------------------------------------------------------------------+----+--------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
+ i  |                                                  j                                                   | i  |                                                       j                                                        
+----+------------------------------------------------------------------------------------------------------+----+----------------------------------------------------------------------------------------------------------------
+  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, hash_join_count, hist_time_ubounds, hist_time_freq from pg_mon where hash_join_count > 0;
@@ -152,18 +227,18 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
- i  |                                                  j                                                   | i  |                                             j                                              
-----+------------------------------------------------------------------------------------------------------+----+--------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
+ i  |                                                  j                                                   | i  |                                                       j                                                        
+----+------------------------------------------------------------------------------------------------------+----+----------------------------------------------------------------------------------------------------------------
+  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, merge_join_count, hist_time_ubounds, hist_time_freq from pg_mon where merge_join_count > 0;
@@ -186,18 +261,18 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
- i  |                                                  j                                                   | i  |                                             j                                              
-----+------------------------------------------------------------------------------------------------------+----+--------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
+ i  |                                                  j                                                   | i  |                                                       j                                                        
+----+------------------------------------------------------------------------------------------------------+----+----------------------------------------------------------------------------------------------------------------
+  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where nested_loop_join_count > 0;
@@ -221,18 +296,18 @@ select pg_stat_statements_reset();
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
- i  |                                                  j                                                   | i  |                                             j                                              
-----+------------------------------------------------------------------------------------------------------+----+--------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
+ i  |                                                  j                                                   | i  |                                                       j                                                        
+----+------------------------------------------------------------------------------------------------------+----+----------------------------------------------------------------------------------------------------------------
+  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where nested_loop_join_count > 0;
@@ -256,18 +331,18 @@ select pg_mon_reset();
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
- i  |                                                  j                                                   | i  |                                             j                                              
-----+------------------------------------------------------------------------------------------------------+----+--------------------------------------------------------------------------------------------
-  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
-  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
- 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | sdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedcsdsfefedc
+ i  |                                                  j                                                   | i  |                                                       j                                                        
+----+------------------------------------------------------------------------------------------------------+----+----------------------------------------------------------------------------------------------------------------
+  1 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  1 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  2 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  2 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  3 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  3 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  4 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  4 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  5 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  5 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  6 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  6 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  7 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  7 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  8 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  8 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+  9 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h |  9 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
+ 10 | bsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3hbsdshkjd3h | 10 | test_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_montest_pg_mon
 (10 rows)
 
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where expected_rows = 0 and actual_rows = 10;

--- a/sql/pg_mon.sql
+++ b/sql/pg_mon.sql
@@ -3,8 +3,8 @@ create extension pg_stat_statements;
 
 create table t (i int, j text);
 create table t2 (i int, j text);
-insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));
-insert into t2 values (generate_series(1,10), repeat('sdsfefedc', 10));
+insert into t values (generate_series(1,10), repeat('test_pg_mon', 10));
+insert into t2 values (generate_series(1,10), repeat('test_pg_mon', 10));
 analyze t;
 analyze t2;
 
@@ -32,6 +32,35 @@ select expected_rows, actual_rows, index_scans, bitmap_scans, hist_time_ubounds,
 set enable_bitmapscan = 'off';
 select * from t where i < 5;
 select expected_rows, actual_rows, seq_scans, index_scans, bitmap_scans, hist_time_ubounds, hist_time_freq from pg_mon where seq_scans IS NOT NULL and index_scans IS NOT NULL;
+
+--Scan information for update statements
+set enable_indexscan = 'on';
+set enable_bitmapscan = 'on';
+update t set i = 11 where i = 1;
+select seq_scans,  index_scans, update_query from pg_mon where update_query = true;
+select pg_mon_reset();
+select pg_stat_statements_reset();
+
+set enable_indexscan = 'off';
+set enable_bitmapscan = 'off';
+update t set i = 1;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+
+--Scan information for delete statements
+select pg_mon_reset();
+select pg_stat_statements_reset();
+set enable_indexscan = 'on';
+set enable_bitmapscan = 'on';
+delete from t where i < 5;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+select pg_mon_reset();
+select pg_stat_statements_reset();
+
+set enable_indexscan = 'off';
+set enable_bitmapscan = 'off';
+delete from t;
+select seq_scans, index_scans, update_query from pg_mon where update_query = true;
+insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));
 
 --Join output
 select pg_mon_reset();


### PR DESCRIPTION
If the query contains update statements, then also save the information of the scans used.